### PR TITLE
Fix hot module reload

### DIFF
--- a/lib/addStylesShadow.js
+++ b/lib/addStylesShadow.js
@@ -24,13 +24,18 @@ function addStyles (styles /* Array<StyleObject> */, shadowRoot) {
     (shadowRoot._injectedStyles = {})
   for (var i = 0; i < styles.length; i++) {
     var item = styles[i]
-    var style = injectedStyles[item.id]
-    if (!style) {
-      for (var j = 0; j < item.parts.length; j++) {
-        addStyle(item.parts[j], shadowRoot)
+    var existingStyles = injectedStyles[item.id]
+    if (existingStyles) {
+      for (var j = 0; j < existingStyles.length; j++) {
+        existingStyles[j].remove()
       }
-      injectedStyles[item.id] = true
     }
+
+    var newStyles = []
+    for (var j = 0; j < item.parts.length; j++) {
+      newStyles[j] = addStyle(item.parts[j], shadowRoot)
+    }
+    injectedStyles[item.id] = newStyles
   }
 }
 
@@ -67,4 +72,6 @@ function addStyle (obj /* StyleObjectPart */, shadowRoot) {
     }
     styleElement.appendChild(document.createTextNode(css))
   }
+
+  return styleElement
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-style-loader",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "author": "Evan You",
   "description": "Vue.js style loader module for webpack",
   "repository": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Prior to this change, `addStylesToShadowDOM` would ignore styles it had already added. When developing using Hot Module Reload, it is necessary to replace existing style elements instead. 

**Did you add tests for your changes?**
No, there are no existing tests for `addStylesShadow.js`. Perhaps there should be, but the changes would be larger than the scope of this PR.

**If relevant, did you update the README?**
No, the README does not reference shadow mode at all. Perhaps it should, but the changes would be larger than the scope of this PR.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
I use HMR in my projects, and templates update as expected. Styles do not. This solves #38 

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
This is not a breaking change.

**Other information**
